### PR TITLE
Error starting Mesos Slaves

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ mesosMaster:
 #
 mesosSlave1:
   image: redjack/mesos-slave:0.21.0
+  privileged: true
   ports:
     - "5051:5051"
   links:
@@ -49,6 +50,7 @@ mesosSlave1:
     - /sys/fs/cgroup:/sys/fs/cgroup
 mesosSlave2:
   image: redjack/mesos-slave:0.21.0
+  privileged: true
   ports:
     - "5052:5052"
   links:
@@ -66,6 +68,7 @@ mesosSlave2:
     - "mesosSlave1"
 mesosSlave3:
   image: redjack/mesos-slave:0.21.0
+  privileged: true
   ports:
     - "5053:5053"
   links:


### PR DESCRIPTION
All Mesos Slaves processes were failing due to permission denied on docker host.
Added "privileged:true" configuration to docker container startup.
